### PR TITLE
Cleanup DevOps

### DIFF
--- a/tasks/e2e-behavior.sh
+++ b/tasks/e2e-behavior.sh
@@ -77,8 +77,7 @@ yarn
 startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 
 # Publish the monorepo
-git clean -df
-./tasks/publish.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
+publishToLocalRegistry
 
 # ******************************************************************************
 # Now that we have published them, run all tests as if they were released.

--- a/tasks/e2e-installs.sh
+++ b/tasks/e2e-installs.sh
@@ -99,8 +99,7 @@ yarn
 startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 
 # Publish the monorepo
-git clean -df
-./tasks/publish.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
+publishToLocalRegistry
 
 echo "Create React App Version: "
 npx create-react-app --version

--- a/tasks/e2e-kitchensink-eject.sh
+++ b/tasks/e2e-kitchensink-eject.sh
@@ -81,8 +81,7 @@ yarn
 startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 
 # Publish the monorepo
-git clean -df
-./tasks/publish.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
+publishToLocalRegistry
 
 # ******************************************************************************
 # Now that we have published them, create a clean app folder and install them.

--- a/tasks/e2e-kitchensink.sh
+++ b/tasks/e2e-kitchensink.sh
@@ -81,8 +81,7 @@ yarn
 startLocalRegistry "$root_path"/tasks/verdaccio.yaml
 
 # Publish the monorepo
-git clean -df
-./tasks/publish.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
+publishToLocalRegistry
 
 # ******************************************************************************
 # Now that we have published them, create a clean app folder and install them.

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -138,8 +138,8 @@ CI=true yarn test
 # Test local start command
 yarn start --smoke-test
 
-git clean -df
-./tasks/publish.sh --yes --force-publish=* --skip-git --cd-version=prerelease --exact --npm-tag=latest
+# Publish the monorepo
+publishToLocalRegistry
 
 # ******************************************************************************
 # Install react-scripts prerelease via create-react-app prerelease.

--- a/tasks/local-registry.sh
+++ b/tasks/local-registry.sh
@@ -29,3 +29,8 @@ function stopLocalRegistry {
   # Kill Verdaccio process
   ps -ef | grep 'verdaccio' | grep -v grep | awk '{print $2}' | xargs kill -9
 }
+
+function publishToLocalRegistry {
+  git clean -df
+  ./tasks/publish.sh prerelease --yes --force-publish=* --no-git-tag-version --no-commit-hooks --no-push --exact --dist-tag=latest
+}

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -31,7 +31,6 @@ if [ -z $CI ]; then
 fi
 
 if [ -n "$(git status --porcelain)" ]; then
-  echo "$(git diff)"
   echo "Your git status is not clean. Aborting.";
   exit 1;
 fi


### PR DESCRIPTION
A little cleanup from the previous PR (#2).

/cc @willsmythe. I spent some time looking through the Lerna docs, and it looks like we still weren't quite up-to-date with v3. Does my updated `publish` command look okay from what you know?

TODO:
- [ ] Doesn't look like we're exiting scripts properly as seen in https://dev.azure.com/ianschmitz/test-cra/_build/results?buildId=29. It continues on with the `lerna publish` even though `git status` check fails?
